### PR TITLE
Fixed size cropping and minor improvements / bugfixes

### DIFF
--- a/cropgtk.py
+++ b/cropgtk.py
@@ -174,7 +174,7 @@ class DragManager(DragManagerBase):
                 gtk.gdk.COLORSPACE_RGB, 0, 8,
                 rendered.size[0], rendered.size[1], 3*rendered.size[0])
 
-            ll, tt, rr, bb = self.get_corners()
+            tt, ll, rr, bb = self.get_corners()
             ratio = self.describe_ratio()
 
             g['pos_left'].set_text('%d' % ll)
@@ -234,11 +234,11 @@ class App:
             self.set_busy()
             try:
                 i = Image.open(image_name)
-                iw, ih = i.size
-                iz = max(iw, ih)
+                drag.w, drag.h = i.size
+                iz = max(drag.w, drag.h)
                 scale = max(1, iz/max_sz)
                 print iz, scale, max_sz
-                i.thumbnail((iw/scale, ih/scale))
+                i.thumbnail((drag.w/scale, drag.h/scale))
             except (IOError,), detail:
                 m = gtk.MessageDialog(self['window1'],
                     gtk.DIALOG_MODAL | gtk.DIALOG_DESTROY_WITH_PARENT,
@@ -250,7 +250,6 @@ class App:
                 continue
             drag.image = i
             drag.rotation = image_rotation(i)
-            drag.round = max(1, 8./scale)
             drag.scale = scale
             self.set_busy(0)
             v = self.drag.wait()

--- a/cropgtk.py
+++ b/cropgtk.py
@@ -259,10 +259,10 @@ class App:
                 continue # user hit "next" / escape
             
             t, l, r, b = drag.top, drag.left, drag.right, drag.bottom
-            t *= scale
-            l *= scale
-            r *= scale
-            b *= scale
+#            t *= scale
+#            l *= scale
+#            r *= scale
+#            b *= scale
             cropspec = "%dx%d+%d+%d" % (r-l, b-t, l, t)
             command = ['nice', 'jpegtran']
             if   drag.rotation == 3: command.extend(['-rotate', '180'])

--- a/cropgtk.py
+++ b/cropgtk.py
@@ -198,7 +198,6 @@ class DragManager(DragManagerBase):
 
 max_h = gtk.gdk.screen_height() - 64*3
 max_w = gtk.gdk.screen_width() - 64
-max_sz = min(max_w, max_h)
 
 class App:
     def __init__(self):
@@ -235,9 +234,9 @@ class App:
             try:
                 i = Image.open(image_name)
                 drag.w, drag.h = i.size
-                iz = max(drag.w, drag.h)
-                scale = max(1, iz/max_sz)
-                print iz, scale, max_sz
+                scale = 1
+                scale = max (scale, (drag.w-1)/max_w+1)
+                scale = max (scale, (drag.h-1)/max_h+1)
                 i.thumbnail((drag.w/scale, drag.h/scale))
             except (IOError,), detail:
                 m = gtk.MessageDialog(self['window1'],

--- a/cropgtk.py
+++ b/cropgtk.py
@@ -259,10 +259,6 @@ class App:
                 continue # user hit "next" / escape
             
             t, l, r, b = drag.top, drag.left, drag.right, drag.bottom
-#            t *= scale
-#            l *= scale
-#            r *= scale
-#            b *= scale
             cropspec = "%dx%d+%d+%d" % (r-l, b-t, l, t)
             command = ['nice', 'jpegtran']
             if   drag.rotation == 3: command.extend(['-rotate', '180'])

--- a/cropgui.py
+++ b/cropgui.py
@@ -56,6 +56,11 @@ crop43_button.pack(side="left")
 crop43 = Tkinter.Menu(crop43_button)
 crop43_button.config(menu=crop43)
 
+crop11_button = Tkinter.Menubutton(app, text="1:1")
+crop11_button.pack(side="left")
+crop11 = Tkinter.Menu(crop11_button)
+crop11_button.config(menu=crop11)
+
 crop34_button = Tkinter.Menubutton(app, text="3:4")
 crop34_button.pack(side="left")
 crop34 = Tkinter.Menu(crop34_button)
@@ -182,6 +187,7 @@ crop169.add_command(label='1920 x 1080',command=lambda: drag.set_stdsize(1920,10
 crop169.add_command(label='4000 x 2248',command=lambda: drag.set_stdsize(4000,2248))
 
 crop85.add_command (label='1920 x 1200',command=lambda: drag.set_stdsize(1920,1200))
+crop85.add_command (label='3376 x 2112',command=lambda: drag.set_stdsize(3376,2112))
 crop85.add_command (label='4000 x 2496',command=lambda: drag.set_stdsize(4000,2496))
 
 crop32.add_command (label='1136 x  760',command=lambda: drag.set_stdsize(1136, 760))
@@ -191,6 +197,7 @@ crop32.add_command (label='1752 x 1168',command=lambda: drag.set_stdsize(1752,11
 crop32.add_command (label='2048 x 1360',command=lambda: drag.set_stdsize(2048,1360))
 crop32.add_command (label='2592 x 1728',command=lambda: drag.set_stdsize(2592,1728))
 crop32.add_command (label='3072 x 2048',command=lambda: drag.set_stdsize(3072,2048))
+crop32.add_command (label='4000 x 2664',command=lambda: drag.set_stdsize(4000,2664))
 
 crop43.add_command (label='1280 x  960',command=lambda: drag.set_stdsize(1280, 960))
 crop43.add_command (label='1600 x 1200',command=lambda: drag.set_stdsize(1600,1200))
@@ -198,6 +205,9 @@ crop43.add_command (label='1720 x 1280',command=lambda: drag.set_stdsize(1720,12
 crop43.add_command (label='2048 x 1536',command=lambda: drag.set_stdsize(2048,1536))
 crop43.add_command (label='2560 x 1920',command=lambda: drag.set_stdsize(2560,1920))
 crop43.add_command (label='2816 x 2112',command=lambda: drag.set_stdsize(2816,2112))
+crop43.add_command (label='3000 x 2248',command=lambda: drag.set_stdsize(3000,2248))
+
+crop11.add_command (label='3000 x 3000',command=lambda: drag.set_stdsize(3000,3000))
 
 crop34.add_command (label=' 960 x 1280',command=lambda: drag.set_stdsize( 960,1280))
 crop34.add_command (label='1200 x 1600',command=lambda: drag.set_stdsize(1200,1600))
@@ -273,11 +283,7 @@ try:
 
         # call jpegtran
         base, ext = os.path.splitext(image_name)
-        t, l, r, b = drag.top, drag.left, drag.right, drag.bottom
-        t *= scale
-        l *= scale
-        r *= scale
-        b *= scale
+        t, l, r, b = drag.get_corners()
         cropspec = "%dx%d+%d+%d" % (r-l, b-t, l, t)
         target = base + "-crop" + ext
         task.add(['nice', 'jpegtran', '-copy', 'all', '-crop', cropspec, image_name], target)

--- a/cropgui.py
+++ b/cropgui.py
@@ -227,7 +227,7 @@ crop23.add_command (label='1168 x 1752',command=lambda: drag.set_stdsize(1168,17
 crop23.add_command (label='1360 x 2048',command=lambda: drag.set_stdsize(1360,2048))
 crop23.add_command (label='1728 x 2592',command=lambda: drag.set_stdsize(1728,2592))
 crop23.add_command (label='2048 x 3072',command=lambda: drag.set_stdsize(2048,3072))
-crop32.add_command (label='2664 x 4000',command=lambda: drag.set_stdsize(2664,2000))
+crop23.add_command (label='2664 x 4000',command=lambda: drag.set_stdsize(2664,4000))
 
 
 def image_names():

--- a/cropgui.py
+++ b/cropgui.py
@@ -207,7 +207,7 @@ try:
         b *= scale
         cropspec = "%dx%d+%d+%d" % (r-l, b-t, l, t)
         target = base + "-crop" + ext
-                task.add(['nice', 'jpegtran', '-copy', 'all', '-crop', cropspec, image_name], target)
+        task.add(['nice', 'jpegtran', '-copy', 'all', '-crop', cropspec, image_name], target)
 finally:
     task.done()
 

--- a/cropgui.py
+++ b/cropgui.py
@@ -36,11 +36,35 @@ preview.pack(side="bottom")
 do_crop = Tkinter.Button(app, text="Crop")
 do_crop.pack(side="left")
 
-stdsize_button = Tkinter.Menubutton(app, text="Size")
-stdsize_button.pack(side="left")
-stdsize = Tkinter.Menu(stdsize_button)
-stdsize_button.config(menu=stdsize)
+crop169_button = Tkinter.Menubutton(app, text="16:9")
+crop169_button.pack(side="left")
+crop169 = Tkinter.Menu(crop169_button)
+crop169_button.config(menu=crop169)
 
+crop85_button = Tkinter.Menubutton(app, text="8:5")
+crop85_button.pack(side="left")
+crop85 = Tkinter.Menu(crop85_button)
+crop85_button.config(menu=crop85)
+
+crop32_button = Tkinter.Menubutton(app, text="3:2")
+crop32_button.pack(side="left")
+crop32 = Tkinter.Menu(crop32_button)
+crop32_button.config(menu=crop32)
+
+crop43_button = Tkinter.Menubutton(app, text="4:3")
+crop43_button.pack(side="left")
+crop43 = Tkinter.Menu(crop43_button)
+crop43_button.config(menu=crop43)
+
+crop34_button = Tkinter.Menubutton(app, text="3:4")
+crop34_button.pack(side="left")
+crop34 = Tkinter.Menu(crop34_button)
+crop34_button.config(menu=crop34)
+
+crop23_button = Tkinter.Menubutton(app, text="2:3")
+crop23_button.pack(side="left")
+crop23 = Tkinter.Menu(crop23_button)
+crop23_button.config(menu=crop23)
 
 info = Tkinter.Label(app)
 info.pack(side="left")
@@ -154,7 +178,41 @@ max_w = app.winfo_screenwidth() - 64
 drag = DragManager(preview, do_crop, info)
 app.wm_protocol('WM_DELETE_WINDOW', drag.close)
 
-stdsize.add_command(label='2112x2816',command=lambda: drag.set_stdsize(2112,2816))
+crop169.add_command(label='1920 x 1080',command=lambda: drag.set_stdsize(1920,1080))
+crop169.add_command(label='4000 x 2250',command=lambda: drag.set_stdsize(4000,2250))
+
+crop85.add_command (label='1920 x 1200',command=lambda: drag.set_stdsize(1920,1200))
+crop85.add_command (label='4000 x 2500',command=lambda: drag.set_stdsize(4000,2500))
+
+crop43.add_command (label='1280 x  960',command=lambda: drag.set_stdsize(1280, 960))
+crop43.add_command (label='1600 x 1200',command=lambda: drag.set_stdsize(1600,1200))
+crop43.add_command (label='1720 x 1280',command=lambda: drag.set_stdsize(1720,1280))
+crop43.add_command (label='2048 x 1536',command=lambda: drag.set_stdsize(2048,1536))
+crop43.add_command (label='2560 x 1920',command=lambda: drag.set_stdsize(2560,1920))
+crop43.add_command (label='2816 x 2112',command=lambda: drag.set_stdsize(2816,2112))
+
+crop32.add_command (label='1134 x  756',command=lambda: drag.set_stdsize(1134, 756))
+crop32.add_command (label='1440 x  960',command=lambda: drag.set_stdsize(1440, 960))
+crop32.add_command (label='1536 x 1024',command=lambda: drag.set_stdsize(1536,1024))
+crop32.add_command (label='1756 x 1168',command=lambda: drag.set_stdsize(1756,1168))
+crop32.add_command (label='2048 x 1360',command=lambda: drag.set_stdsize(2048,1360))
+crop32.add_command (label='2592 x 1728',command=lambda: drag.set_stdsize(2592,1728))
+crop32.add_command (label='3072 x 2048',command=lambda: drag.set_stdsize(3072,2048))
+
+crop23.add_command (label=' 756 x 1134',command=lambda: drag.set_stdsize( 756,1134))
+crop23.add_command (label=' 960 x 1440',command=lambda: drag.set_stdsize( 960,1440))
+crop23.add_command (label='1024 x 1536',command=lambda: drag.set_stdsize(1024,1536))
+crop23.add_command (label='1168 x 1756',command=lambda: drag.set_stdsize(1168,1756))
+crop23.add_command (label='1360 x 2048',command=lambda: drag.set_stdsize(1360,2048))
+crop23.add_command (label='1728 x 2592',command=lambda: drag.set_stdsize(1728,2592))
+crop23.add_command (label='2048 x 3072',command=lambda: drag.set_stdsize(2048,3072))
+
+crop34.add_command (label=' 960 x 1280',command=lambda: drag.set_stdsize( 960,1280))
+crop34.add_command (label='1200 x 1600',command=lambda: drag.set_stdsize(1200,1600))
+crop34.add_command (label='1280 x 1720',command=lambda: drag.set_stdsize(1280,1720))
+crop34.add_command (label='1536 x 2048',command=lambda: drag.set_stdsize(1536,2048))
+crop34.add_command (label='1920 x 2560',command=lambda: drag.set_stdsize(1920,2560))
+crop34.add_command (label='2112 x 2816',command=lambda: drag.set_stdsize(2112,2816))
 
 
 def image_names():

--- a/cropgui.py
+++ b/cropgui.py
@@ -116,7 +116,7 @@ class DragManager(DragManagerBase):
             self.inf.configure(text="\n\n")
             return
 
-        ll, tt, rr, bb = self.get_corners()
+        tt, ll, rr, bb = self.get_corners()
         ratio = self.describe_ratio()
         self.inf.configure(text=
             "Left:  %4d  Top:    %4d    Right: %4d  Bottom: %4d\n"
@@ -250,24 +250,32 @@ def set_busy(new_busy=True):
 
 try:
     for image_name in image_names():
+        # load new image
         set_busy()
         i = Image.open(image_name)
+
+        # compute scale to fit image on display
         iw, ih = i.size
         scale=1
         while iw > max_w or ih > max_h:
             iw /= 2
             ih /= 2
             scale *= 2
+
+        # put original size, image, and scale into drag object
+        drag.w, drag.h = i.size
         i.thumbnail((iw, ih))
         drag.image = i
-        drag.round = max(1, 8/scale)
         drag.scale = scale
+
+        # get user input
         set_busy(0)
         v = drag.wait()
         set_busy()
         if v == -1: break   # user closed app
         if v == 0: continue # user hit "next" / escape
-        
+
+        # call jpegtran
         base, ext = os.path.splitext(image_name)
         t, l, r, b = drag.top, drag.left, drag.right, drag.bottom
         t *= scale

--- a/cropgui.py
+++ b/cropgui.py
@@ -184,10 +184,11 @@ drag = DragManager(preview, do_crop, info)
 app.wm_protocol('WM_DELETE_WINDOW', drag.close)
 
 crop169.add_command(label='1920 x 1080',command=lambda: drag.set_stdsize(1920,1080))
+crop169.add_command(label='3840 x 2160',command=lambda: drag.set_stdsize(3840,2160))
 crop169.add_command(label='4000 x 2248',command=lambda: drag.set_stdsize(4000,2248))
 
 crop85.add_command (label='1920 x 1200',command=lambda: drag.set_stdsize(1920,1200))
-crop85.add_command (label='3376 x 2112',command=lambda: drag.set_stdsize(3376,2112))
+crop85.add_command (label='3456 x 2160',command=lambda: drag.set_stdsize(3456,2160))
 crop85.add_command (label='4000 x 2496',command=lambda: drag.set_stdsize(4000,2496))
 
 crop32.add_command (label='1136 x  760',command=lambda: drag.set_stdsize(1136, 760))
@@ -204,8 +205,9 @@ crop43.add_command (label='1600 x 1200',command=lambda: drag.set_stdsize(1600,12
 crop43.add_command (label='1720 x 1280',command=lambda: drag.set_stdsize(1720,1280))
 crop43.add_command (label='2048 x 1536',command=lambda: drag.set_stdsize(2048,1536))
 crop43.add_command (label='2560 x 1920',command=lambda: drag.set_stdsize(2560,1920))
-crop43.add_command (label='2816 x 2112',command=lambda: drag.set_stdsize(2816,2112))
-crop43.add_command (label='3000 x 2248',command=lambda: drag.set_stdsize(3000,2248))
+crop43.add_command (label='2880 x 2160',command=lambda: drag.set_stdsize(2880,2160))
+crop43.add_command (label='4000 x 3000',command=lambda: drag.set_stdsize(4000,3000))
+crop43.add_command (label='4320 x 3240',command=lambda: drag.set_stdsize(4320,3240))
 
 crop11.add_command (label='3000 x 3000',command=lambda: drag.set_stdsize(3000,3000))
 
@@ -214,7 +216,9 @@ crop34.add_command (label='1200 x 1600',command=lambda: drag.set_stdsize(1200,16
 crop34.add_command (label='1280 x 1720',command=lambda: drag.set_stdsize(1280,1720))
 crop34.add_command (label='1536 x 2048',command=lambda: drag.set_stdsize(1536,2048))
 crop34.add_command (label='1920 x 2560',command=lambda: drag.set_stdsize(1920,2560))
-crop34.add_command (label='2112 x 2816',command=lambda: drag.set_stdsize(2112,2816))
+crop34.add_command (label='2160 x 2880',command=lambda: drag.set_stdsize(2160,2880))
+crop34.add_command (label='3000 x 4000',command=lambda: drag.set_stdsize(3000,4000))
+crop34.add_command (label='3240 x 4320',command=lambda: drag.set_stdsize(3240,4320))
 
 crop23.add_command (label=' 760 x 1136',command=lambda: drag.set_stdsize( 760,1136))
 crop23.add_command (label=' 960 x 1440',command=lambda: drag.set_stdsize( 960,1440))
@@ -223,6 +227,7 @@ crop23.add_command (label='1168 x 1752',command=lambda: drag.set_stdsize(1168,17
 crop23.add_command (label='1360 x 2048',command=lambda: drag.set_stdsize(1360,2048))
 crop23.add_command (label='1728 x 2592',command=lambda: drag.set_stdsize(1728,2592))
 crop23.add_command (label='2048 x 3072',command=lambda: drag.set_stdsize(2048,3072))
+crop32.add_command (label='2664 x 4000',command=lambda: drag.set_stdsize(2664,2000))
 
 
 def image_names():

--- a/cropgui.py
+++ b/cropgui.py
@@ -198,6 +198,7 @@ crop32.add_command (label='1752 x 1168',command=lambda: drag.set_stdsize(1752,11
 crop32.add_command (label='2048 x 1360',command=lambda: drag.set_stdsize(2048,1360))
 crop32.add_command (label='2592 x 1728',command=lambda: drag.set_stdsize(2592,1728))
 crop32.add_command (label='3072 x 2048',command=lambda: drag.set_stdsize(3072,2048))
+crop32.add_command (label='3240 x 2160',command=lambda: drag.set_stdsize(3240,2160))
 crop32.add_command (label='4000 x 2664',command=lambda: drag.set_stdsize(4000,2664))
 
 crop43.add_command (label='1280 x  960',command=lambda: drag.set_stdsize(1280, 960))

--- a/cropgui.py
+++ b/cropgui.py
@@ -255,18 +255,14 @@ try:
         i = Image.open(image_name)
 
         # compute scale to fit image on display
-        iw, ih = i.size
-        scale=1
-        while iw > max_w or ih > max_h:
-            iw /= 2
-            ih /= 2
-            scale *= 2
-
-        # put original size, image, and scale into drag object
         drag.w, drag.h = i.size
-        i.thumbnail((iw, ih))
+        drag.scale=1
+        drag.scale = max (drag.scale, (drag.w-1)/max_w+1)
+        drag.scale = max (drag.scale, (drag.h-1)/max_h+1)
+
+        # put image into drag object
+        i.thumbnail((drag.w/drag.scale, drag.h/drag.scale))
         drag.image = i
-        drag.scale = scale
 
         # get user input
         set_busy(0)

--- a/cropgui.py
+++ b/cropgui.py
@@ -179,10 +179,18 @@ drag = DragManager(preview, do_crop, info)
 app.wm_protocol('WM_DELETE_WINDOW', drag.close)
 
 crop169.add_command(label='1920 x 1080',command=lambda: drag.set_stdsize(1920,1080))
-crop169.add_command(label='4000 x 2250',command=lambda: drag.set_stdsize(4000,2250))
+crop169.add_command(label='4000 x 2248',command=lambda: drag.set_stdsize(4000,2248))
 
 crop85.add_command (label='1920 x 1200',command=lambda: drag.set_stdsize(1920,1200))
-crop85.add_command (label='4000 x 2500',command=lambda: drag.set_stdsize(4000,2500))
+crop85.add_command (label='4000 x 2496',command=lambda: drag.set_stdsize(4000,2496))
+
+crop32.add_command (label='1136 x  760',command=lambda: drag.set_stdsize(1136, 760))
+crop32.add_command (label='1440 x  960',command=lambda: drag.set_stdsize(1440, 960))
+crop32.add_command (label='1536 x 1024',command=lambda: drag.set_stdsize(1536,1024))
+crop32.add_command (label='1752 x 1168',command=lambda: drag.set_stdsize(1752,1168))
+crop32.add_command (label='2048 x 1360',command=lambda: drag.set_stdsize(2048,1360))
+crop32.add_command (label='2592 x 1728',command=lambda: drag.set_stdsize(2592,1728))
+crop32.add_command (label='3072 x 2048',command=lambda: drag.set_stdsize(3072,2048))
 
 crop43.add_command (label='1280 x  960',command=lambda: drag.set_stdsize(1280, 960))
 crop43.add_command (label='1600 x 1200',command=lambda: drag.set_stdsize(1600,1200))
@@ -191,28 +199,20 @@ crop43.add_command (label='2048 x 1536',command=lambda: drag.set_stdsize(2048,15
 crop43.add_command (label='2560 x 1920',command=lambda: drag.set_stdsize(2560,1920))
 crop43.add_command (label='2816 x 2112',command=lambda: drag.set_stdsize(2816,2112))
 
-crop32.add_command (label='1134 x  756',command=lambda: drag.set_stdsize(1134, 756))
-crop32.add_command (label='1440 x  960',command=lambda: drag.set_stdsize(1440, 960))
-crop32.add_command (label='1536 x 1024',command=lambda: drag.set_stdsize(1536,1024))
-crop32.add_command (label='1756 x 1168',command=lambda: drag.set_stdsize(1756,1168))
-crop32.add_command (label='2048 x 1360',command=lambda: drag.set_stdsize(2048,1360))
-crop32.add_command (label='2592 x 1728',command=lambda: drag.set_stdsize(2592,1728))
-crop32.add_command (label='3072 x 2048',command=lambda: drag.set_stdsize(3072,2048))
-
-crop23.add_command (label=' 756 x 1134',command=lambda: drag.set_stdsize( 756,1134))
-crop23.add_command (label=' 960 x 1440',command=lambda: drag.set_stdsize( 960,1440))
-crop23.add_command (label='1024 x 1536',command=lambda: drag.set_stdsize(1024,1536))
-crop23.add_command (label='1168 x 1756',command=lambda: drag.set_stdsize(1168,1756))
-crop23.add_command (label='1360 x 2048',command=lambda: drag.set_stdsize(1360,2048))
-crop23.add_command (label='1728 x 2592',command=lambda: drag.set_stdsize(1728,2592))
-crop23.add_command (label='2048 x 3072',command=lambda: drag.set_stdsize(2048,3072))
-
 crop34.add_command (label=' 960 x 1280',command=lambda: drag.set_stdsize( 960,1280))
 crop34.add_command (label='1200 x 1600',command=lambda: drag.set_stdsize(1200,1600))
 crop34.add_command (label='1280 x 1720',command=lambda: drag.set_stdsize(1280,1720))
 crop34.add_command (label='1536 x 2048',command=lambda: drag.set_stdsize(1536,2048))
 crop34.add_command (label='1920 x 2560',command=lambda: drag.set_stdsize(1920,2560))
 crop34.add_command (label='2112 x 2816',command=lambda: drag.set_stdsize(2112,2816))
+
+crop23.add_command (label=' 760 x 1136',command=lambda: drag.set_stdsize( 760,1136))
+crop23.add_command (label=' 960 x 1440',command=lambda: drag.set_stdsize( 960,1440))
+crop23.add_command (label='1024 x 1536',command=lambda: drag.set_stdsize(1024,1536))
+crop23.add_command (label='1168 x 1752',command=lambda: drag.set_stdsize(1168,1752))
+crop23.add_command (label='1360 x 2048',command=lambda: drag.set_stdsize(1360,2048))
+crop23.add_command (label='1728 x 2592',command=lambda: drag.set_stdsize(1728,2592))
+crop23.add_command (label='2048 x 3072',command=lambda: drag.set_stdsize(2048,3072))
 
 
 def image_names():

--- a/cropgui.py
+++ b/cropgui.py
@@ -31,10 +31,18 @@ app.wm_title(_("CropGUI -- lossless cropping and rotation of jpeg files"))
 app.wm_iconname(_("CropGUI"))
 
 preview = Tkinter.Label(app)
-do_crop = Tkinter.Button(app, text="Crop")
-info = Tkinter.Label(app)
 preview.pack(side="bottom")
+
+do_crop = Tkinter.Button(app, text="Crop")
 do_crop.pack(side="left")
+
+stdsize_button = Tkinter.Menubutton(app, text="Size")
+stdsize_button.pack(side="left")
+stdsize = Tkinter.Menu(stdsize_button)
+stdsize_button.config(menu=stdsize)
+
+
+info = Tkinter.Label(app)
 info.pack(side="left")
 
 task = CropTask(log)
@@ -145,6 +153,9 @@ max_w = app.winfo_screenwidth() - 64
 
 drag = DragManager(preview, do_crop, info)
 app.wm_protocol('WM_DELETE_WINDOW', drag.close)
+
+stdsize.add_command(label='2112x2816',command=lambda: drag.set_stdsize(2112,2816))
+
 
 def image_names():
     if len(sys.argv) > 1:

--- a/cropgui_common.py
+++ b/cropgui_common.py
@@ -156,21 +156,31 @@ class DragManagerBase(object):
         return describe_ratio(w, h)
 
     def set_stdsize(self, x, y):
+        # convert to screen coordinates
         x /= self.scale
-        x = min (x, self.w)
+        y /= self.scale
+
+        # if frame doesn't fit in image, scale, preserving apect ratio
+        if (x > self.w):
+            x = self.w
+            y = y * self.w / x
+        if (y > self.h):
+            y = self.h
+            x = x * self.h / y
+
+        # calculate new crop area, preserving center
         left = (self.left + self.right - x) / 2
         right = left + x
+        top = (self.top + self.bottom - y) / 2
+        bottom = top + y
+
+        # move crop area into the image, if necessairy
         if (left < 0):
             left = 0
             right = x
         if (right > self.w):
             right = self.w
             left = right - x
-            
-        y /= self.scale
-        y = min (y, self.h)
-        top = (self.top + self.bottom - y) / 2
-        bottom = top + y
         if (top < 0):
             top = 0
             bottom = y

--- a/cropgui_common.py
+++ b/cropgui_common.py
@@ -93,9 +93,8 @@ class DragManagerBase(object):
     def __init__(self):
         self.render_flag = 0
         self.show_handles = True
-        self.round = 8
         self.state = DRAG_NONE
-        self.round = 1
+        self.round = 8
         self.image = None
         self.w = 0
         self.h = 0
@@ -138,7 +137,8 @@ class DragManagerBase(object):
         a, b = sorted((b,a))
         a = clamp(a, 0, lim)
         b = clamp(b, 0, lim)
-        a = math.floor(a * 1. / self.round)*self.round
+        a = (a / self.round)*self.round
+        b = (b / self.round)*self.round
         return int(a), int(b)
 
     def get_corners(self):

--- a/cropgui_common.py
+++ b/cropgui_common.py
@@ -155,6 +155,31 @@ class DragManagerBase(object):
         h = self.bottom - self.top
         return describe_ratio(w, h)
 
+    def set_stdsize(self, x, y):
+        x /= self.scale
+        x = min (x, self.w)
+        left = (self.left + self.right - x) / 2
+        right = left + x
+        if (left < 0):
+            left = 0
+            right = x
+        if (right > self.w):
+            right = self.w
+            left = right - x
+            
+        y /= self.scale
+        y = min (y, self.h)
+        top = (self.top + self.bottom - y) / 2
+        bottom = top + y
+        if (top < 0):
+            top = 0
+            bottom = y
+        if (bottom > self.h):
+            bottom = self.h
+            top = bottom - y
+            
+        self.set_crop (top, left, right, bottom)
+
     def set_crop(self, top, left, right, bottom):
         self.top, self.bottom = self.fix(top, bottom, self.h)
         self.left, self.right = self.fix(left, right, self.w)

--- a/cropgui_common.py
+++ b/cropgui_common.py
@@ -291,11 +291,11 @@ class DragManagerBase(object):
         if self.state == DRAG_C:
             # A center drag bumps into the edges
             if dx > 0:
-                dx = min(dx, self.w - self.r0 - 1)
+                dx = min(dx, self.w - self.r0)
             else:
                 dx = max(dx, -self.l0)
             if dy > 0:
-                dy = min(dy, self.h - self.b0 - 1)
+                dy = min(dy, self.h - self.b0)
             else:
                 dy = max(dy, -self.t0)
         if self.state in (DRAG_TL, DRAG_T, DRAG_TR, DRAG_C):

--- a/cropgui_common.py
+++ b/cropgui_common.py
@@ -162,11 +162,11 @@ class DragManagerBase(object):
 
         # if frame doesn't fit in image, scale, preserving apect ratio
         if (x > self.w):
-            x = self.w
             y = y * self.w / x
+            x = self.w
         if (y > self.h):
-            y = self.h
             x = x * self.h / y
+            y = self.h
 
         # calculate new crop area, preserving center
         left = (self.left + self.right - x) / 2

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+cropgui (0.2+git27ee40aeee) hardy; urgency=low
+
+  * use absoloute paths
+  * don't apply scaling to jpegtrans dimensions
+
+ -- Reuben <reuben_p@yahoo.com> Thu, 30 Jul 2015 07:04:00 +1000
+
 cropgui (0.2) hardy; urgency=low
 
   * remember directory for 'open' file choosers


### PR DESCRIPTION
- Main new feature: in cropgui.py, you can select the size of the cropped image from menues among several standard sizes. This feature is partially implemented in cropgui_common.py, so it should be easy to add it to cropgtk.py. [dea4c6a, 3c8ac4c, b349397, 3409320, 22d06c2, 370f4fb]
- Internal representation of w,h,left,right,top,bottom changed to image coordinates. This prevents size changes when moving the crop region which occured due to rounding errors. [ef5ba8f, 1d1fb3e]
- Computation of scale by same algorithm in cropgui.py and cropgtk.py. The old algorithm in cropgui.py only gave powers of two. The old algorithm in cropgtk was completely different and could result in too small images (because it fit the larger image dimension in the smaller screen dimension, e.g. image.w into screen.h) [2babc8d]
- Misc small bugfixes [d53aedf, 236c151, 2714048]
