### PR TITLE
Change tostring() into tobytes() so no exception is thrown

### DIFF
--- a/cropgtk.py
+++ b/cropgtk.py
@@ -170,7 +170,7 @@ class DragManager(DragManagerBase):
             rendered = self.rendered()
             rendered = rendered.convert('RGB')
             i.set_size_request(*rendered.size)
-            pixbuf = gtk.gdk.pixbuf_new_from_data(rendered.tostring(),
+            pixbuf = gtk.gdk.pixbuf_new_from_data(rendered.tobytes(),
                 gtk.gdk.COLORSPACE_RGB, 0, 8,
                 rendered.size[0], rendered.size[1], 3*rendered.size[0])
 

--- a/filechooser.py
+++ b/filechooser.py
@@ -49,7 +49,7 @@ def update_preview_cb(file_chooser, preview):
             i.thumbnail((PREVIEW_SIZE, PREVIEW_SIZE), Image.ANTIALIAS)
             i = i.convert('RGB')
             i = apply_rotation(r, i)
-            pixbuf = gtk.gdk.pixbuf_new_from_data(i.tostring(), 
+            pixbuf = gtk.gdk.pixbuf_new_from_data(i.tobytes(), 
                 gtk.gdk.COLORSPACE_RGB, 0, 8, i.size[0], i.size[1],
                 i.size[0]*3)
             preview.set_from_pixbuf(pixbuf)


### PR DESCRIPTION
Newer versions of PyGTK throw an exception when tostring() is used, this changes it so images can be loaded again.