### PR TITLE
Make desktop file follows the specification

### DIFF
--- a/cropgui.desktop
+++ b/cropgui.desktop
@@ -1,6 +1,4 @@
 [Desktop Entry]
-Encoding=UTF-8
-Version=
 Type=Application
 Exec=/usr/bin/cropgui
 Icon=cropgui
@@ -9,5 +7,5 @@ Terminal=false
 Name=Crop Photos
 Comment=Losslessly Crop JPEG and other images.
 StartupNotify=false
-Categories=Application;Graphics;2DGraphics;RasterGraphics;GTK;
-MimeType=image/*
+Categories=Graphics;2DGraphics;RasterGraphics;GTK;
+MimeType=image/*;


### PR DESCRIPTION
In short - desktop-file-validate from desktop-file-utils packages throws errors and warnings on cropgui.desktop

pinkbyte@oas1 ~/dev/cropgui $ desktop-file-validate cropgui.desktop
cropgui.desktop: warning: key "Encoding" in group "Desktop Entry" is deprecated
cropgui.desktop: error: value "" for key "Version" in group "Desktop Entry" is not a known version
cropgui.desktop: warning: value "Application;Graphics;2DGraphics;RasterGraphics;GTK;" for key "Categories" in group "Desktop Entry" contains a deprecated value "Application"
cropgui.desktop: error: value "image/*" for string list key "MimeType" in group "Desktop Entry" does not have a semicolon (';') as trailing character

Suggested changes make it happy :-)