### PR TITLE
Crop all image types using Magick

### DIFF
--- a/cropgtk.py
+++ b/cropgtk.py
@@ -290,7 +290,7 @@ class App:
             else: 
                 command = ['nice', 'convert']
                 if not rotation == "none": command.extend(['-rotate', rotation])
-                command.extend([image_name, '-crop', cropspec, target])
+                command.extend([image_name, '+repage', '-crop', cropspec, target])
             print " ".join(command)
             task.add(command, target)
 

--- a/cropgtk.py
+++ b/cropgtk.py
@@ -238,6 +238,11 @@ class App:
             self.set_busy()
             try:
                 i = Image.open(image_name)
+                if i.format == "JPEG":
+                    drag.round = 8
+                else:
+                    drag.round = 1
+
                 drag.w, drag.h = i.size
                 scale = 1
                 scale = max (scale, (drag.w-1)/max_w+1)

--- a/cropgui.py
+++ b/cropgui.py
@@ -271,6 +271,10 @@ try:
         # load new image
         set_busy()
         i = Image.open(image_name)
+        if i.format == "JPEG":
+            drag.round = 8
+        else:
+            drag.round = 1
 
         # compute scale to fit image on display
         drag.w, drag.h = i.size
@@ -289,12 +293,16 @@ try:
         if v == -1: break   # user closed app
         if v == 0: continue # user hit "next" / escape
 
-        # call jpegtran
+        # compute parameters for command line of cropping tool
         base, ext = os.path.splitext(image_name)
         t, l, r, b = drag.get_corners()
         cropspec = "%dx%d+%d+%d" % (r-l, b-t, l, t)
         target = base + "-crop" + ext
-        task.add(['nice', 'jpegtran', '-copy', 'all', '-crop', cropspec, '-outfile', target, image_name], target)
+
+        if i.format == "JPEG":
+            task.add(['nice', 'jpegtran', '-copy', 'all', '-crop', cropspec, '-outfile', target, image_name], target)
+        else:
+            task.add(['nice', 'convert',                  '-crop', cropspec,             image_name, target], target)
 finally:
     task.done()
 

--- a/cropgui.py
+++ b/cropgui.py
@@ -298,11 +298,12 @@ try:
         t, l, r, b = drag.get_corners()
         cropspec = "%dx%d+%d+%d" % (r-l, b-t, l, t)
         target = base + "-crop" + ext
+        print cropspec
 
         if i.format == "JPEG":
             task.add(['nice', 'jpegtran', '-copy', 'all', '-crop', cropspec, '-outfile', target, image_name], target)
         else:
-            task.add(['nice', 'convert',                  '-crop', cropspec,             image_name, target], target)
+            task.add(['nice', 'convert',  image_name,     '-crop', cropspec,             target],             target)
 finally:
     task.done()
 

--- a/cropgui.py
+++ b/cropgui.py
@@ -301,9 +301,9 @@ try:
         print cropspec
 
         if i.format == "JPEG":
-            task.add(['nice', 'jpegtran', '-copy', 'all', '-crop', cropspec, '-outfile', target, image_name], target)
+            task.add(['nice', 'jpegtran', '-copy',    'all',     '-crop', cropspec, '-outfile', target, image_name], target)
         else:
-            task.add(['nice', 'convert',  image_name,     '-crop', cropspec,             target],             target)
+            task.add(['nice', 'convert',  image_name, '+repage', '-crop', cropspec,             target],             target)
 finally:
     task.done()
 

--- a/cropgui.py
+++ b/cropgui.py
@@ -190,6 +190,8 @@ crop169.add_command(label='4000 x 2248',command=lambda: drag.set_stdsize(4000,22
 crop85.add_command (label='1920 x 1200',command=lambda: drag.set_stdsize(1920,1200))
 crop85.add_command (label='3456 x 2160',command=lambda: drag.set_stdsize(3456,2160))
 crop85.add_command (label='4000 x 2496',command=lambda: drag.set_stdsize(4000,2496))
+crop85.add_command (label='4000 x 2496',command=lambda: drag.set_stdsize(4000,2496))
+crop85.add_command (label='5184 x 3240',command=lambda: drag.set_stdsize(5184,3240))
 
 crop32.add_command (label='1136 x  760',command=lambda: drag.set_stdsize(1136, 760))
 crop32.add_command (label='1440 x  960',command=lambda: drag.set_stdsize(1440, 960))

--- a/cropgui_common.py
+++ b/cropgui_common.py
@@ -137,7 +137,7 @@ class DragManagerBase(object):
         b = clamp(b, 0, lim)
         a = (a / self.round)*self.round
         b = (b / self.round)*self.round
-        return int(a), int(b)
+        return int(a+0.5), int(b+0.5)
 
     def get_corners(self):
         return self.top, self.left, self.right, self.bottom

--- a/cropgui_common.py
+++ b/cropgui_common.py
@@ -82,9 +82,11 @@ class CropTask(object):
                 break
             command, target = task
             shortname = os.path.basename(target)
-            self.log.progress(_("Cropping to %s") % shortname)
+            self.log.log(_("Cropping to %s") % shortname)
             subprocess.call(command)
-            subprocess.call(["jpegexiforient", "-1", target])
+            if command[1]=="jpegtran":
+                self.log.log(_("Setting exif orientation of %s") % shortname)
+                subprocess.call(["jpegexiforient", "-1", target])
             self.log.log(_("Cropped to %s") % shortname)
 
 class DragManagerBase(object):


### PR DESCRIPTION
Someone had added cropping of non jpeg images via convert from Image Magick.
Though this is lossy, which many applications can do, I find it useful.
This is because most other applications require more clicks to crop an image.

I applied the following fixes to this functionality:
• added to cropgui.py (was only in cropgtk.py before)
• added +repage to the command line (required at least for certain png)
• did not try to run jpegexiforient on non jpeg images

cropgtk also had and still has a minor problem with attempts of reading exif of non jpeg images.
Moreover, you might want to refactor CropTask. Hardcoded jpegexiforient is bad style and required a nasty hack to avoid jpegexiforient on non jpeg images.