### PR TITLE
remove unused code

### DIFF
--- a/filechooser.py
+++ b/filechooser.py
@@ -141,6 +141,3 @@ class DirChooser(BaseChooser):
 
     def set_current_folder(self, directory):
         self.dialog.set_current_folder(directory)
-
-if __name__ == '__main__':
-    print prompt_open()


### PR DESCRIPTION
This code uses `prompt_open()`, which was removed in 45eaaedd7519305345a9e5b1945ec705f1970df8.