### PR TITLE
don't hardcode TIOCGWINSZ value

### DIFF
--- a/log.py
+++ b/log.py
@@ -18,16 +18,15 @@ import fcntl
 import os
 import struct
 import sys
+import termios
 import threading
 
 lock = threading.RLock()
 
-TIOCGWINSZ = 0x5413
-
 screen_width = screen_height = None
 def screen_size():
     if not os.isatty(2): return 0, 0
-    res = fcntl.ioctl(2, TIOCGWINSZ, "\0" * 4)
+    res = fcntl.ioctl(2, termios.TIOCGWINSZ, "\0" * 4)
     return struct.unpack("hh", res)
 screen_width, screen_height = screen_size()
 


### PR DESCRIPTION
The `TIOCGWINSZ` constant is available in the `termios` module, so let's use it instead of hardcoding the value.