### PR TITLE
Copy file if no cropping or rotation is required.

### DIFF
--- a/cropgtk.py
+++ b/cropgtk.py
@@ -281,8 +281,11 @@ class App:
                 self.log("Skipped %s" % os.path.basename(image_name))
                 continue # user hit "cancel" on save dialog
 
+            # Copy file if no cropping or rotation.
+            if (r+b-l-t) == (drag.w+drag.h) and rotation =="none":
+                command = ['nice', 'cp' , image_name, target]
             # JPEG crop uses jpegtran
-            if image_type is "jpeg":
+            elif image_type is "jpeg":
                 command = ['nice', 'jpegtran']
                 if not rotation == "none": command.extend(['-rotate', rotation])
                 command.extend(['-copy', 'all', '-crop', cropspec,'-outfile', target, image_name])

--- a/cropgui.py
+++ b/cropgui.py
@@ -287,12 +287,18 @@ try:
         if v == -1: break   # user closed app
         if v == 0: continue # user hit "next" / escape
 
+        # Copy file if no cropping.
+        if (r+b-l-t) == (drag.w+drag.h):
+            command = ['nice', 'cp' , image_name, target]
         # call jpegtran
-        base, ext = os.path.splitext(image_name)
-        t, l, r, b = drag.get_corners()
-        cropspec = "%dx%d+%d+%d" % (r-l, b-t, l, t)
-        target = base + "-crop" + ext
-        task.add(['nice', 'jpegtran', '-copy', 'all', '-crop', cropspec, '-outfile', target, image_name], target)
+        else:
+            base, ext = os.path.splitext(image_name)
+            t, l, r, b = drag.get_corners()
+            cropspec = "%dx%d+%d+%d" % (r-l, b-t, l, t)
+            target = base + "-crop" + ext
+            command=['nice', 'jpegtran', '-copy', 'all', '-crop', cropspec, '-outfile', target, image_name]
+        print " ".join(command)
+        task.add(command, target)
 finally:
     task.done()
 


### PR DESCRIPTION
Through testing it was discovered that jpegtran still modifies files when no cropping or rotation is given (0 pixels, 0 degrees).  Using imagemagick to compare resulting reconstructed images pixel by pixel it was determined that no pixel values are actually changed by jpegtran in this case, however these images always grow in file size (minimally).

This commit fixes this by simply copying the target file if no cropping or rotating is required.  I wasn't sure of the best way to implement this, but I think it makes sense output a file whenever a user clicks 'crop,' even if no crop pixels or rotation are given.  If a user doesn't want to output a file, they can select 'skip,' instead.