### PR TITLE
Consider IMCU size when rounding and viewing jpeg crops.

### DIFF
--- a/cropgtk.py
+++ b/cropgtk.py
@@ -23,7 +23,7 @@ import gtk
 import gtk.glade
 
 import filechooser
-
+import subprocess
 import sys
 import traceback
 import imghdr
@@ -238,6 +238,17 @@ class App:
             self.set_busy()
             try:
                 i = Image.open(image_name)
+
+                # Use IMCU size to round jpeg dragging and cropping.
+                if i.format == "JPEG":
+                    sampling = subprocess.check_output(
+                        'identify -format "%[jpeg:sampling-factor]" "'+
+                        image_name+'"', shell=True)
+                    drag.roundW = int(sampling.split(',')[0].split('x')[0]) * 8
+                    drag.roundH = int(sampling.split(',')[0].split('x')[1]) * 8
+                else:
+                    drag.roundW = drag.roundH = 1
+
                 drag.w, drag.h = i.size
                 scale = 1
                 scale = max (scale, (drag.w-1)/max_w+1)

--- a/cropgui.py
+++ b/cropgui.py
@@ -23,7 +23,6 @@ import ImageTk
 import tkFileDialog
 import sys
 import subprocess
-import subprocess
 import os
 import signal
 import log
@@ -271,16 +270,6 @@ try:
         # load new image
         set_busy()
         i = Image.open(image_name)
-
-        # Use IMCU size to round jpeg dragging and cropping.
-        if i.format == "JPEG":
-            sampling = subprocess.check_output(
-                'identify -format "%[jpeg:sampling-factor]" "'+
-                image_name+'"', shell=True)
-            drag.roundW = int(sampling.split(',')[0].split('x')[0]) * 8
-            drag.roundH = int(sampling.split(',')[0].split('x')[1]) * 8
-        else:
-            drag.roundW = drag.roundH = 1
 
         # Use IMCU size to round jpeg dragging and cropping.
         if i.format == "JPEG":

--- a/cropgui.py
+++ b/cropgui.py
@@ -22,6 +22,8 @@ import Tkinter
 import ImageTk
 import tkFileDialog
 import sys
+import subprocess
+import subprocess
 import os
 import signal
 import log
@@ -269,6 +271,26 @@ try:
         # load new image
         set_busy()
         i = Image.open(image_name)
+
+        # Use IMCU size to round jpeg dragging and cropping.
+        if i.format == "JPEG":
+            sampling = subprocess.check_output(
+                'identify -format "%[jpeg:sampling-factor]" "'+
+                image_name+'"', shell=True)
+            drag.roundW = int(sampling.split(',')[0].split('x')[0]) * 8
+            drag.roundH = int(sampling.split(',')[0].split('x')[1]) * 8
+        else:
+            drag.roundW = drag.roundH = 1
+
+        # Use IMCU size to round jpeg dragging and cropping.
+        if i.format == "JPEG":
+            sampling = subprocess.check_output(
+                'identify -format "%[jpeg:sampling-factor]" "'+
+                image_name+'"', shell=True)
+            drag.roundW = int(sampling.split(',')[0].split('x')[0]) * 8
+            drag.roundH = int(sampling.split(',')[0].split('x')[1]) * 8
+        else:
+            drag.roundW = drag.roundH = 1
 
         # compute scale to fit image on display
         drag.w, drag.h = i.size

--- a/cropgui_common.py
+++ b/cropgui_common.py
@@ -92,7 +92,8 @@ class DragManagerBase(object):
         self.render_flag = 0
         self.show_handles = True
         self.state = DRAG_NONE
-        self.round = 8
+        self.roundW = 8
+        self.roundH = 8
         self.image = None
         self.w = 0
         self.h = 0
@@ -131,12 +132,12 @@ class DragManagerBase(object):
         self.image_set()
         self.render()
 
-    def fix(self, a, b, lim):
+    def fix(self, a, b, lim, roundN):
         a, b = sorted((b,a))
         a = clamp(a, 0, lim)
         b = clamp(b, 0, lim)
-        a = (a / self.round)*self.round
-        b = (b / self.round)*self.round
+        a = (a / roundN)*roundN
+        b = (b / roundN)*roundN
         return int(a), int(b)
 
     def get_corners(self):
@@ -183,8 +184,8 @@ class DragManagerBase(object):
         self.set_crop (top, left, right, bottom)
 
     def set_crop(self, top, left, right, bottom):
-        self.top, self.bottom = self.fix(top, bottom, self.h)
-        self.left, self.right = self.fix(left, right, self.w)
+        self.top, self.bottom = self.fix(top, bottom, self.h, self.roundH)
+        self.left, self.right = self.fix(left, right, self.w, self.roundW)
         self.render()
 
     def get_image(self):


### PR DESCRIPTION
This commit uses imagemagick's `identify` command to determine jpeg IMCU size.

To do so, I had to import subprocess into `cropgtk.py` in order to call `identify` on each new image as it's drawn.  Also, instead of a single rounding variable `self.round` in `cropgui_common.py`, there are now two variables `self.roundW` and `self.roundH` for the respective cases.