### PR TITLE
Switching from jpegexiforient to exiftool

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ upper-left corner must be at a multiple of 8x8 original image pixels.
 
 cropgui is written in Python and requires the following packages:
  * Debian: python, python-tkinter, python-imaging, python-imaging-tk,
-   and libjpeg-progs.
+   libjpeg-progs, and libimage-exiftool-perl.
  * Fedora: python2-pillow, libjpeg-turbo-utils, pygtk2,
-   pygtk2-libglade, and ImageMagick.
+   pygtk2-libglade, ImageMagick, and perl-Image-ExifTool.
 
 It is available under the terms of the GNU GPL version 2 or later.
 
 The specific external programs required are:
  * `jpegtran` to crop jpeg images (debian package: libjpeg-turbo-progs or libjpeg-progs)
- * `jpegexiforient` to clear the EXIF rotation flag from jpeg output images (debian package: libjpeg-turbo-progs or libjpeg-progs)
+ * `exiftool` to clear the EXIF rotation flag from jpeg output images (debian package: libimage-exiftool-perl)
  * `convert` to rotate and crop other image types (debian package: imagemagick or graphicsmagick-imagemagick-compat)

--- a/README.md
+++ b/README.md
@@ -26,9 +26,13 @@ order to fit onscreen. After releasing the mouse button, the cropped image
 boundary may move a little bit; this represents the limitation that the
 upper-left corner must be at a multiple of 8x8 original image pixels.
 
-cropgui is written in Python and requires python, python-tkinter,
-python-imaging, python-imaging-tk, and libjpeg-progs. It is available under the
-terms of the GNU GPL version 2 or later. 
+cropgui is written in Python and requires the following packages:
+ * Debian: python, python-tkinter, python-imaging, python-imaging-tk,
+   and libjpeg-progs.
+ * Fedora: python2-pillow, libjpeg-turbo-utils, pygtk2,
+   pygtk2-libglade, and ImageMagick.
+
+It is available under the terms of the GNU GPL version 2 or later.
 
 The specific external programs required are:
  * `jpegtran` to crop jpeg images (debian package: libjpeg-turbo-progs or libjpeg-progs)

--- a/cropgui_common.py
+++ b/cropgui_common.py
@@ -84,7 +84,7 @@ class CropTask(object):
             shortname = os.path.basename(target)
             self.log.progress(_("Cropping to %s") % shortname)
             subprocess.call(command)
-            subprocess.call(["jpegexiforient", "-1", target])
+            subprocess.call(["exiftool", "-overwrite_original", "-Orientation=1", "-n", target])
             self.log.log(_("Cropped to %s") % shortname)
 
 class DragManagerBase(object):


### PR DESCRIPTION
The main reason is that jpegexiforient is not available in Fedora (as of 26). I think it's an old program and is no longer maintained. The current popular tool to manipulate EXIF information is the exiftool. The change is straightforward and simple. I've tested it on a few images, and it worked correctly.