### PR TITLE
Rotate image before scaling

### DIFF
--- a/cropgtk.py
+++ b/cropgtk.py
@@ -238,11 +238,6 @@ class App:
             self.set_busy()
             try:
                 i = Image.open(image_name)
-                drag.w, drag.h = i.size
-                scale = 1
-                scale = max (scale, (drag.w-1)/max_w+1)
-                scale = max (scale, (drag.h-1)/max_h+1)
-                i.thumbnail((drag.w/scale, drag.h/scale))
             except (IOError,), detail:
                 m = gtk.MessageDialog(self['window1'],
                     gtk.DIALOG_MODAL | gtk.DIALOG_DESTROY_WITH_PARENT,
@@ -253,12 +248,16 @@ class App:
                 m.destroy()
                 continue
             image_type = imghdr.what(image_name)
-            drag.image = i
-            drag.rotation = 1
             rotation = image_rotation(i)
-            if rotation in (3,6,8):
-                while drag.rotation != rotation:
-                    drag.rotate_ccw()
+            if rotation == 3: i = i.transpose(Image.ROTATE_180)
+            if rotation == 6: i = i.transpose(Image.ROTATE_270)
+            if rotation == 8: i = i.transpose(Image.ROTATE_90)
+            drag.w, drag.h = i.size
+            scale = 1
+            scale = max (scale, (drag.w-1)/max_w+1)
+            scale = max (scale, (drag.h-1)/max_h+1)
+            i.thumbnail((drag.w/scale, drag.h/scale))
+            drag.set_image(i, initial_rotation = rotation)
             drag.scale = scale
             self.set_busy(0)
             v = self.drag.wait()

--- a/cropgui_common.py
+++ b/cropgui_common.py
@@ -97,7 +97,7 @@ class DragManagerBase(object):
         self.w = 0
         self.h = 0
 
-    def set_image(self, image):
+    def set_image(self, image,  initial_rotation = 1):
         if image is None:
             if hasattr(self, 'left'): del self.left
             if hasattr(self, 'right'): del self.right
@@ -109,6 +109,7 @@ class DragManagerBase(object):
             self._orig_image = image.copy()
             self._rotation = 1
             self.image_or_rotation_changed()
+            self._rotation = initial_rotation
 
     def apply_rotation(self, image):
         if self.rotation == 1: return image.copy()


### PR DESCRIPTION
If imaged is scaled before rotation it might end up too large for screen
boundaries after rotation.