### PR TITLE
Fix warning with Python 3.8 (is/==).

### DIFF
--- a/cropgtk.py
+++ b/cropgtk.py
@@ -291,7 +291,7 @@ class App:
             if (r+b-l-t) == (drag.w+drag.h) and rotation =="none":
                 command = ['nice', 'cp' , image_name, target]
             # JPEG crop uses jpegtran
-            elif image_type is "jpeg":
+            elif image_type == "jpeg":
                 command = ['nice', 'jpegtran']
                 if not rotation == "none": command.extend(['-rotate', rotation])
                 command.extend(['-copy', 'all', '-crop', cropspec,'-outfile', target, image_name])


### PR DESCRIPTION
With Python 3.8 there is a warning:
```
//usr/lib/python3.8/site-packages/cropgui/cropgtk.py:294: SyntaxWarning: "is" with a literal. Did you mean "=="?
  elif image_type is "jpeg":
```

"is" shouldn't be used for string comparisons, changing it to "==". Please apply.