### PR TITLE
Implement next-power-of-2 image scaling.

### DIFF
--- a/cropgtk.py
+++ b/cropgtk.py
@@ -246,8 +246,8 @@ class App:
                 i = Image.open(image_name)
                 drag.w, drag.h = i.size
                 scale = 1
-                scale = max (scale, (drag.w-1)/(max_w+1))
-                scale = max (scale, (drag.h-1)/(max_h+1))
+                scale = max (scale, nextPowerOf2((drag.w-1)/(max_w+1)))
+                scale = max (scale, nextPowerOf2((drag.h-1)/(max_h+1)))
                 i.thumbnail((drag.w/scale, drag.h/scale))
             except (IOError,) as detail:
                 m = gtk.MessageDialog(self['window1'],

--- a/cropgtk.py
+++ b/cropgtk.py
@@ -246,8 +246,8 @@ class App:
                 i = Image.open(image_name)
                 drag.w, drag.h = i.size
                 scale = 1
-                scale = max (scale, (drag.w-1)/max_w+1)
-                scale = max (scale, (drag.h-1)/max_h+1)
+                scale = max (scale, (drag.w-1)/(max_w+1))
+                scale = max (scale, (drag.h-1)/(max_h+1))
                 i.thumbnail((drag.w/scale, drag.h/scale))
             except (IOError,) as detail:
                 m = gtk.MessageDialog(self['window1'],

--- a/cropgui_common.py
+++ b/cropgui_common.py
@@ -47,6 +47,20 @@ def clamp(value, low, high):
     if high < value: return high
     return value
 
+def nextPowerOf2(n):
+    count = 0;
+    ceiln = math.ceil(n)
+    # First ceiln in the below condition is for the
+    # case where ceiln is 0
+    if (ceiln and not(ceiln & (ceiln - 1))):
+        return ceiln
+
+    while (ceiln != 0):
+        ceiln >>= 1
+        count += 1
+
+    return 1 << count;
+
 def ncpus():
     if os.path.exists("/proc/cpuinfo"):
         return open("/proc/cpuinfo").read().count("bogomips") or 1


### PR DESCRIPTION
Documentation states:

> Images are automatically scaled by a power of 2 (e.g., 1/2, 1/4 or 1/8) in order to fit onscreen.

Implement just that; that happens to prevent fractional scaling that caused, at least on my machine, a wrong-sized drag region.