### PR TITLE
Improve rounding behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ write the result.
 
 It turns out that debian's jpegtran has a "-crop" flag which performs lossless
 cropping of jpeg images as long as the crop is to a multiple of what the
-manpage calls the "iMCU boundary", a (usually?) 8x8 block of pixels. This
-feature may have been pioneered by Guido of jpegclub.org some years ago.
+manpage calls the "iMCU boundary", usually an 8x8 or 16x16 block of pixels.
+This feature may have been pioneered by Guido of jpegclub.org some years ago.
 
 There's apparently a nice Windows front-end to this program, but I didn't find
 a Linux one. So I wrote one! It's pretty basic, but it gets the job done. You

--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ overwrite an earlier cropped version). For example, if the input is "moon.jpg"
 then the output is "moon-cropped.jpg".
 
 Images are automatically scaled by a power of 2 (e.g., 1/2, 1/4 or 1/8) in
-order to fit onscreen. After releasing the mouse button, the cropped image
-boundary may move a little bit; this represents the limitation that the
-upper-left corner must be at a multiple of 8x8 original image pixels.
+order to fit onscreen. While dragging, the cropped image boundary will snap
+to a multiple of 8 or 16 pixels; this represents the limitation that the
+upper-left corner must be at a multiple of the iMCU blocks.
 
 ## PREREQUISITES
 

--- a/cropgtk.py
+++ b/cropgtk.py
@@ -244,6 +244,7 @@ class App:
             self.set_busy()
             try:
                 i = Image.open(image_name)
+                drag.round_x, drag.round_y = image_round(i)
                 drag.w, drag.h = i.size
                 scale = 1
                 scale = max (scale, nextPowerOf2((drag.w-1)/(max_w+1)))

--- a/cropgui.py
+++ b/cropgui.py
@@ -270,8 +270,9 @@ try:
         set_busy()
         i = Image.open(image_name)
 
-        # compute scale to fit image on display
+        drag.round_x, drag.round_y = image_round(i)
         drag.w, drag.h = i.size
+        # compute scale to fit image on display
         drag.scale=1
         drag.scale = max (drag.scale, (drag.w-1)/max_w+1)
         drag.scale = max (drag.scale, (drag.h-1)/max_h+1)

--- a/cropgui_common.py
+++ b/cropgui_common.py
@@ -147,10 +147,10 @@ class DragManagerBase(object):
 
     def fix(self, a, b, lim):
         a, b = sorted((int(a), int(b)))
+        a = (a // self.round)*self.round
+        b = ((b + self.round - 1) // self.round)*self.round
         a = clamp(a, 0, lim)
         b = clamp(b, 0, lim)
-        a = (a // self.round)*self.round
-        b = (b // self.round)*self.round
         return a, b
 
     def get_corners(self):

--- a/cropgui_common.py
+++ b/cropgui_common.py
@@ -146,19 +146,19 @@ class DragManagerBase(object):
         self.render()
 
     def fix(self, a, b, lim):
-        a, b = sorted((b,a))
+        a, b = sorted((int(a), int(b)))
         a = clamp(a, 0, lim)
         b = clamp(b, 0, lim)
-        a = (a / self.round)*self.round
-        b = (b / self.round)*self.round
-        return int(a), int(b)
+        a = (a // self.round)*self.round
+        b = (b // self.round)*self.round
+        return a, b
 
     def get_corners(self):
         return self.top, self.left, self.right, self.bottom
 
     def get_screencorners(self):
         t, l, r, b = self.get_corners()
-        return(int(t/int(self.scale)), int(l/int(self.scale)), 
+        return(int(t/int(self.scale)), int(l/int(self.scale)),
                int(r/int(self.scale)), int(b/int(self.scale)))
 
     def describe_ratio(self):


### PR DESCRIPTION
- Use integer division in `fix`, so we actually round and make the crop boundary snap while dragging
- Round right/bottom up instead of rounding down
- Automatically determine iMCU size
- Round coordinates correctly for rotated images

Fixes #31, fixes #52, fixes #56
