### PR TITLE
Fix output name detection for non-jpeg files

### DIFF
--- a/cropgtk.py
+++ b/cropgtk.py
@@ -321,7 +321,7 @@ class App:
         if image_type == "jpeg":
             if e.lower() in ['.jpg', '.jpeg']: return r
             return e + ".jpg"
-        elif e.lower() == image_type: return r
+        elif e.lower() == "." + image_type: return r
         else: return e + "." + image_type
 
 app = App()


### PR DESCRIPTION
This fixes the problem, when the png files are saved as ".png.png".