### PR TITLE
Updates of possible interest

### DIFF
--- a/cropgtk.py
+++ b/cropgtk.py
@@ -293,7 +293,7 @@ class App:
         if len(sys.argv) > 1:
             for i in sys.argv[1:]: yield i
         else:
-            c = filechooser.Chooser(self['window1'], _("Select images to crop"))
+            c = filechooser.Chooser(_("Select images to crop"), self['window1'])
             while 1:
                 files = c.run()
                 if not files: break
@@ -309,7 +309,7 @@ class App:
         if os.access(d, os.W_OK): return os.path.join(d, j)
         title = _('Save cropped version of %s') % i
         if self.dirchooser is None:
-            self.dirchooser = filechooser.DirChooser(self['window1'], title)
+            self.dirchooser = filechooser.DirChooser(title, self['window1'])
             self.dirchooser.set_current_folder(desktop_name())
         else:
             self.dirchooser.set_title(title)

--- a/cropgtk.py
+++ b/cropgtk.py
@@ -293,7 +293,7 @@ class App:
         if len(sys.argv) > 1:
             for i in sys.argv[1:]: yield i
         else:
-            c = filechooser.Chooser(_("Select images to crop"), self['window1'])
+            c = filechooser.Chooser(self['window1'], _("Select images to crop"))
             while 1:
                 files = c.run()
                 if not files: break
@@ -309,7 +309,7 @@ class App:
         if os.access(d, os.W_OK): return os.path.join(d, j)
         title = _('Save cropped version of %s') % i
         if self.dirchooser is None:
-            self.dirchooser = filechooser.DirChooser(title, self['window1'])
+            self.dirchooser = filechooser.DirChooser(self['window1'], title)
             self.dirchooser.set_current_folder(desktop_name())
         else:
             self.dirchooser.set_title(title)

--- a/filechooser.py
+++ b/filechooser.py
@@ -92,7 +92,7 @@ class Chooser(BaseChooser):
                gtk.STOCK_OPEN, gtk.ResponseType.OK)
 
     def __init__(self, title, parent):
-        BaseChooser.__init__(self, title, parent)
+        BaseChooser.__init__(self, parent, title)
 
         self.dialog.set_default_response(gtk.ResponseType.OK)
         self.dialog.set_select_multiple(True)

--- a/filechooser.py
+++ b/filechooser.py
@@ -73,6 +73,9 @@ def update_preview_cb(file_chooser, preview):
 
 class BaseChooser:
     def __init__(self, title, parent):
+# Gnome's "attach-modal-dialogs" can be set to false using
+# gnome-tweak-tool in order to enable movable modal dialogs.  No idea
+# how to do that app-specifically though.
         self.dialog = dialog = \
             gtk.FileChooserDialog(title, parent, self.mode, self.buttons)
 
@@ -134,6 +137,7 @@ class DirChooser(BaseChooser):
     def __init__(self, title, parent):
         BaseChooser.__init__(self, title, parent)
         self.dialog.set_default_response(gtk.ResponseType.OK)
+        self.dialog.set_do_overwrite_confirmation(True)
 
     def set_current_name(self, filename):
         self.dialog.set_current_name(filename)

--- a/filechooser.py
+++ b/filechooser.py
@@ -92,7 +92,7 @@ class Chooser(BaseChooser):
                gtk.STOCK_OPEN, gtk.ResponseType.OK)
 
     def __init__(self, title, parent):
-        BaseChooser.__init__(self, parent, title)
+        BaseChooser.__init__(self, title, parent)
 
         self.dialog.set_default_response(gtk.ResponseType.OK)
         self.dialog.set_select_multiple(True)

--- a/filechooser.py
+++ b/filechooser.py
@@ -92,7 +92,7 @@ class Chooser(BaseChooser):
                gtk.STOCK_OPEN, gtk.ResponseType.OK)
 
     def __init__(self, title, parent):
-        BaseChooser.__init__(self, parent, title)
+        BaseChooser.__init__(self, title, parent)
 
         self.dialog.set_default_response(gtk.ResponseType.OK)
         self.dialog.set_select_multiple(True)
@@ -132,7 +132,7 @@ class DirChooser(BaseChooser):
                gtk.STOCK_SAVE, gtk.ResponseType.OK)
 
     def __init__(self, title, parent):
-        BaseChooser.__init__(self, parent, title)
+        BaseChooser.__init__(self, title, parent)
         self.dialog.set_default_response(gtk.ResponseType.OK)
 
     def set_current_name(self, filename):

--- a/generate_test_images.sh
+++ b/generate_test_images.sh
@@ -1,0 +1,15 @@
+#!/bin/sh -e
+
+# Generate some chessboard JPGs for testing with.
+
+dir=test
+[ -d $dir ] || mkdir $dir
+
+convert -size 100x100 pattern:gray50 -scale 1600% -sampling-factor 2x2 \
+    -crop 796x396+0+0 $dir/chess-2x2.jpg
+convert -size 100x100 pattern:gray50 -scale 800%x1600% -sampling-factor 1x2 \
+    -crop 796x396+0+0 $dir/chess-1x2.jpg
+convert -size 100x100 pattern:gray50 -scale 1600%x800% -sampling-factor 2x1 \
+    -crop 796x396+0+0 $dir/chess-2x1.jpg
+convert -size 100x100 pattern:gray50 -scale 800% -sampling-factor 1x1 \
+    -crop 796x396+0+0 $dir/chess-1x1.jpg

--- a/install.sh
+++ b/install.sh
@@ -47,21 +47,21 @@ if [ -z "$FLAVOR" ]; then FLAVOR=`default_flavor`; fi
 mkdir -p $TARGET$BINDIR $TARGET$LIBDIR $TARGET$SHAREDIR/applications \
     $TARGET$SHAREDIR/pixmaps
 
-cp cropgui.desktop $TARGET$SHAREDIR/applications
-cp cropgui.png $TARGET$SHAREDIR/pixmaps
+install --mode=644 cropgui.desktop $TARGET$SHAREDIR/applications
+install --mode=644 cropgui.png $TARGET$SHAREDIR/pixmaps
 
 case $FLAVOR in
 gtk)
     echo "Installing gtk version of cropgui"
-    cp cropgtk.py $TARGET$BINDIR/cropgui && \
-    cp cropgui_common.py filechooser.py cropgui.glade \
+    install --mode=755 cropgtk.py $TARGET$BINDIR/cropgui && \
+    install --mode=644 cropgui_common.py filechooser.py cropgui.glade \
         stock-rotate-90-16.png stock-rotate-270-16.png \
         $TARGET$LIBDIR
 ;;
 tk)
     echo "Installing tkinter version of cropgui"
-    cp cropgui.py $TARGET$BINDIR/cropgui && \
-    cp log.py cropgui_common.py $TARGET$LIBDIR
+    install --mode=755 cropgui.py $TARGET$BINDIR/cropgui && \
+    install --mode=644 log.py cropgui_common.py $TARGET$LIBDIR
 ;;
 *)
     echo "Unknown flavor $FLAVOR"


### PR DESCRIPTION
Hi Jeff,

Thanks very much for keeping cropgui going.  I've a few updates here which might be of interest:

- Use of 'cp' during install invokes umask which can leave unreadable files installed; use 'install' instead.
- I've added a script to create four test images which help verifying correct behaviour under rotations and different JPEG block sizes.
- Also added some extra keyboard controls for processing multiple images at a time: 's' to allow you to take multiple crops from one image, 'n' to skip to the next, and 'q' to quit.  Hm.  I should probably find somewhere to document these.
- This involved a bugfix to the event handler, where pressing return while processing multiple images would skip on two images rather than just to the next.
- Minor thing, but title/parent parameter order was a bit inconsistent in the file chooser stuff; fixed.

I have another patch which offers correct crop rounding, but am not sure whether it's worth pushing.  The current always-round-to-block-size behaviour for all four edges is overly aggressive, in that the bottom and right edges of any crop don't need to be block-aligned, but unfortunately jpegtran itself doesn't handle this correctly for rotated images even if provided with a valid command line.  I'm looking into trying to produce a patch for that..