### PR TITLE
Work around jpegtran to get correct rotated crops.

### DIFF
--- a/cropgui_common.py
+++ b/cropgui_common.py
@@ -69,9 +69,16 @@ def get_cropspec(image, corners, rotation):
     t, l, r, b = corners
     w = r - l
     h = b - t
-    # Technically this should produce perfect crops, but jpegtran is broken
-    # and so mistakenly rounds out fractional crops on flipped images.  Sigh.
-    return "%dx%d+%d+%d" % (w, h, l, t)
+    # Technically these parameters should straightforwardly produce perfect
+    # crops, but jpegtran is broken here in two regards: (1) it doesn't
+    # recognise perfect rotated crops as such, so the '-perfect' switch
+    # erroneously rejects correctly ICMU-aligned rotate-and-crop commands, and
+    # (2) it mistakenly rounds out crops on rotated/flipped images so that even
+    # the bottom right corner is ICMU-aligned.  Sigh.  Adding the 'f' suffixes
+    # to the dimensions here at least solves (2), and seems to produce the same
+    # results as you get by manually constructing a pipeline of '-perfect'
+    # command lines.
+    return "%dfx%df+%d+%d" % (w, h, l, t)
 
 
 def ncpus():

--- a/generate_test_images.sh
+++ b/generate_test_images.sh
@@ -5,11 +5,12 @@
 dir=test
 [ -d $dir ] || mkdir $dir
 
+text='-density 72 -pointsize 32 -weight Bold -gravity NorthWest -fill rgba(255,0,0,0.5) -annotate +0+0 A -annotate +32+32 B -annotate +64+64 C -annotate +96+96 D -annotate +128+128 E -annotate +160+160 F -annotate +192+192 G -annotate +224+224 H -annotate +256+256 I -annotate +288+288 J -annotate +320+320 K -fill rgba(0,255,0,0.5) -annotate +352+352 L -annotate +384+320 M -annotate +416+288 N -annotate +448+256 O -annotate +480+224 P -annotate +512+192 Q -annotate +544+160 R -annotate +576+128 S -annotate +608+96 T -annotate +640+64 U -annotate +672+32 V -fill rgba(0,0,255,0.5) -annotate +704+0 W -annotate +736+32 X -annotate +768+64 Y'
 convert -size 100x100 pattern:gray50 -scale 1600% -sampling-factor 2x2 \
-    -crop 796x396+0+0 $dir/chess-2x2.jpg
+    -crop 796x396+0+0 $text $dir/chess-2x2.jpg
 convert -size 100x100 pattern:gray50 -scale 800%x1600% -sampling-factor 1x2 \
-    -crop 796x396+0+0 $dir/chess-1x2.jpg
+    -crop 796x396+0+0 $text $dir/chess-1x2.jpg
 convert -size 100x100 pattern:gray50 -scale 1600%x800% -sampling-factor 2x1 \
-    -crop 796x396+0+0 $dir/chess-2x1.jpg
+    -crop 796x396+0+0 $text $dir/chess-2x1.jpg
 convert -size 100x100 pattern:gray50 -scale 800% -sampling-factor 1x1 \
-    -crop 796x396+0+0 $dir/chess-1x1.jpg
+    -crop 796x396+0+0 $text $dir/chess-1x1.jpg


### PR DESCRIPTION
Hi Jeff, so — seem to have cracked this without modifying libjpeg-turbo: even though jpegtran doesn't seem to quite understand what it's doing, using an additional 'f' specifier on dimensions in the crop strings allows production of correctly sized rotated cropped images that (over a few manual tests) are identical to what you can produce using a pipeline of '-perfect' invocations of jpegtran.  This minor change means cropgtk supports the full range of behaviour that you'd expect from the standard: no matter how the input image is rotated, perfect and correctly-sized outputs are generated with ICMU-aligned top-left corners and arbitrary bottom right corners.  Yay!

Thanks again..