### PR TITLE
use the rule of thirds and the directory of the previously chosen file

### DIFF
--- a/cropgtk.py
+++ b/cropgtk.py
@@ -318,10 +318,13 @@ class App:
             for i in sys.argv[1:]: yield i
         else:
             c = filechooser.Chooser(_("Select images to crop"), self['window1'])
+            lastdir = None
             while 1:
-                files = c.run()
+                files = c.run(lastdir)
                 if not files: break
-                for i in files: yield i
+                for i in files:
+                    lastdir = os.path.dirname(i)
+                    yield i
 
     def output_name(self, image_name, image_type, chooser=False, prev_name=None):
         image_name = os.path.abspath(image_name)

--- a/cropgui_common.py
+++ b/cropgui_common.py
@@ -321,8 +321,8 @@ class DragManagerBase(object):
         image = Image.composite(self.image, self.blurred, mask)
 
         if self.show_handles:
-            dx = (r - l) / 4
-            dy = (b - t) / 4
+            dx = (r - l) / 3
+            dy = (b - t) / 3
 
             mask = Image.new('1', self.image.size, 1)
             draw = ImageDraw.Draw(mask)
@@ -331,11 +331,16 @@ class DragManagerBase(object):
             draw.line([l, b, r, b], fill=0)
             draw.line([l, t, l, b], fill=0)
             draw.line([r, t, r, b], fill=0)
+            
+            draw.line([l, t+dy, r, t+dy], fill=0)
+            draw.line([l, b-dy, r, b-dy], fill=0)
+            draw.line([l+dx, t, l+dx, b], fill=0)
+            draw.line([r-dx, t, r-dx, b], fill=0)
 
-            draw.line([l+dx, t, l+dx, t+dy, l, t+dy], fill=0)
-            draw.line([r-dx, t, r-dx, t+dy, r, t+dy], fill=0)
-            draw.line([l+dx, b, l+dx, b-dy, l, b-dy], fill=0)
-            draw.line([r-dx, b, r-dx, b-dy, r, b-dy], fill=0)
+            #draw.line([l+dx, t, l+dx, t+dy, l, t+dy], fill=0)
+            #draw.line([r-dx, t, r-dx, t+dy, r, t+dy], fill=0)
+            #draw.line([l+dx, b, l+dx, b-dy, l, b-dy], fill=0)
+            #draw.line([r-dx, b, r-dx, b-dy, r, b-dy], fill=0)
 
             image = Image.composite(image, self.xor, mask)
         return image

--- a/cropgui_common.py
+++ b/cropgui_common.py
@@ -337,11 +337,6 @@ class DragManagerBase(object):
             draw.line([l+dx, t, l+dx, b], fill=0)
             draw.line([r-dx, t, r-dx, b], fill=0)
 
-            #draw.line([l+dx, t, l+dx, t+dy, l, t+dy], fill=0)
-            #draw.line([r-dx, t, r-dx, t+dy, r, t+dy], fill=0)
-            #draw.line([l+dx, b, l+dx, b-dy, l, b-dy], fill=0)
-            #draw.line([r-dx, b, r-dx, b-dy, r, b-dy], fill=0)
-
             image = Image.composite(image, self.xor, mask)
         return image
 

--- a/filechooser.py
+++ b/filechooser.py
@@ -95,7 +95,7 @@ class Chooser(BaseChooser):
     buttons = (gtk.STOCK_QUIT, gtk.ResponseType.CANCEL,
                gtk.STOCK_OPEN, gtk.ResponseType.OK)
 
-    def __init__(self, title, parent, initdir = None):
+    def __init__(self, title, parent):
         BaseChooser.__init__(self, title, parent)
 
         self.dialog.set_default_response(gtk.ResponseType.OK)

--- a/filechooser.py
+++ b/filechooser.py
@@ -79,7 +79,8 @@ class BaseChooser:
         self.dialog = dialog = \
             gtk.FileChooserDialog(title, parent, self.mode, self.buttons)
 
-    def run(self):
+    def run(self, initdir = None):
+        if initdir: self.dialog.set_current_folder(initdir)
         self.dialog.show()
         response = self.dialog.run()
         self.dialog.hide()
@@ -94,7 +95,7 @@ class Chooser(BaseChooser):
     buttons = (gtk.STOCK_QUIT, gtk.ResponseType.CANCEL,
                gtk.STOCK_OPEN, gtk.ResponseType.OK)
 
-    def __init__(self, title, parent):
+    def __init__(self, title, parent, initdir = None):
         BaseChooser.__init__(self, title, parent)
 
         self.dialog.set_default_response(gtk.ResponseType.OK)


### PR DESCRIPTION
Thank you for your work on cropgui, which is very useful for me. I have made the following modifications to cropgui for my own convenience:
- file chooser dialog in GTK version starts with directory of the previously chosen file (changes in cropgtk.py and filechooser.py);
- auxiliary lines follow the rule of thirds (changes in cropgui_common.py; see https://www.naturettl.com/rule-of-thirds/).
Feel free to merge (all of some of) this changes if you find them useful.