### PR TITLE
Stop using get_primary_monitor()

### DIFF
--- a/cropgtk.py
+++ b/cropgtk.py
@@ -228,7 +228,7 @@ class DragManager(DragManagerBase):
         return self.result
 
 display = gdk.Display().get_default()
-wa = display.get_primary_monitor().get_workarea()
+wa = display.get_monitor(0).get_workarea()
 max_h = wa.height - 192
 max_w = wa.width - 64
 


### PR DESCRIPTION
It doesn't work in Wayland and it is apparently deprecated.

Use get_monitor(0) instead.

Fixes the following error:

Traceback (most recent call last):
  File "/tmp/./cropgtk.py", line 223, in <module>
    wa = display.get_primary_monitor().get_workarea()
AttributeError: 'NoneType' object has no attribute 'get_workarea'

Fixes https://github.com/jepler/cropgui/issues/93.