### PR TITLE
:bug: Replace Image.ANTIALIAS which was removed in Pillow 10

### DIFF
--- a/filechooser.py
+++ b/filechooser.py
@@ -47,7 +47,7 @@ def update_preview_cb(file_chooser, preview):
         try:
             i = Image.open(filename)
             r = cropgui_common.image_rotation(i)
-            i.thumbnail((PREVIEW_SIZE, PREVIEW_SIZE), Image.ANTIALIAS)
+            i.thumbnail((PREVIEW_SIZE, PREVIEW_SIZE), Image.Resampling.LANCZOS)
             i = i.convert('RGB')
             i = apply_rotation(r, i)
             try:


### PR DESCRIPTION
The replacement, Image.Resampling.LANCZOS has been around since version 1.3.3, and ANTIALIAS has long been deprecated.