### PR TITLE
fix cropping of palette images

### DIFF
--- a/cropgui_common.py
+++ b/cropgui_common.py
@@ -238,11 +238,14 @@ class DragManagerBase(object):
         else:
             self.top, self.bottom = self.prev_top, self.prev_bottom
             self.left, self.right = self.prev_left, self.prev_right
-        blurred = image.copy()
-        mult = len(self.image.mode) # replicate filter for L, RGB, RGBA
-        self.blurred = image.copy().filter(
+        if image.mode == 'P':
+            image_rgb = image.copy().convert("RGB")
+        else:
+            image_rgb = image
+        mult = len(image_rgb.mode) # replicate filter for L, RGB, RGBA
+        self.blurred = image_rgb.copy().filter(
             ImageFilter.SMOOTH_MORE).point([x//2 for x in range(256)] * mult)
-        self.xor = image.copy().point([x ^ 128 for x in range(256)] * mult)
+        self.xor = image_rgb.copy().point([x ^ 128 for x in range(256)] * mult)
         self.image_set()
         self.render()
 


### PR DESCRIPTION
Otherwise an error would occur that said `ValueError: cannot filter palette images`.