### PR TITLE
Fix 'NoneType' has no attribute 'lower'

### DIFF
--- a/cropgtk.py
+++ b/cropgtk.py
@@ -344,7 +344,7 @@ class App:
                 m.run()
                 m.destroy()
                 continue
-            image_type = thumbnail.format.lower()
+            image_type = image.format.lower()
             drag.image = thumbnail
             drag.rotation = 1
             rotation = image_rotation(image)

--- a/cropgtk.py
+++ b/cropgtk.py
@@ -344,7 +344,7 @@ class App:
                 m.run()
                 m.destroy()
                 continue
-            image_type = image.format.lower()
+            image_type = image.format.lower() if image.format else "png"
             drag.image = thumbnail
             drag.rotation = 1
             rotation = image_rotation(image)


### PR DESCRIPTION
It's a mystery to me how this passed my local testing. `thumbnail`
is an image copy which is [documented](https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.format)
to be None in that case.

Retrieve the format property from the originally opened image instead.

Closes #123

@spvkgn please test if you can